### PR TITLE
add description for non-standardized jitterBufferFlushes stat

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,28 @@
       The <dfn>bar</dfn> attribute.
     </p>
   </section>
+  <section id="RTCAudioReceiverStats-dict*">
+    <h3>
+      <dfn>RTCAudioReceiverStats</dfn> dictionary non-standardized members
+    </h3>
+    <pre class="idl">partial dictionary RTCAudioReceiverStats {
+      unsigned long long jitterBufferFlushes;
+};</pre>
+    <dl data-link-for="RTCAudioReceiverStats" data-dfn-for="RTCAudioReceiverStats" class=
+    "dictionary-members">
+      <dt>
+        <dfn><code>jitterBufferFlushes</code></dfn> of type
+        <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-unsigned-long-long">unsigned long long</a></span>
+      </dt>
+      <dd>
+        <p>
+          Experimental stat which is available <a href="https://docs.google.com/document/d/1stYIZhEmDZ7NJF9gjjsM66eLFJUdc-14a3QutrFbIwI/edit#" title="experiment description">under origin trial in Chromium starting from M72 version</a>.
+          Counts the total number of times the jitter buffer
+          reaches its maximum capacity and gets flushed.
+        </p>
+      </dd>
+    </dl>
+  </section>
 </body>
 
 </html>


### PR DESCRIPTION
The version which emphasizes that it is an ongoing experiment available only under origin trial.